### PR TITLE
Add Skiff.com

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -289,6 +289,7 @@ This repository is regularly backed up in [archive.org](https://web.archive.org/
 ## Email
 
 - [ProtonMail](https://protonmail.com/) Secure Email Based in Switzerland
+- [Skiff Mail](https://skiff.com/) Privacy-first end-to-end encrypted email. Supports custom domain.
 - [10 Minute Mail](https://10minutemail.net/) Disposable, private mailboxes
 - [Cock.li](https://cock.li/) Yeah it's mail with cocks
 - [Tutanota](https://tutanota.com/) Secure, open source email service


### PR DESCRIPTION
Skiff provides 10 GB storage, free custom domain, and privacy-centric, end-to-end encrypted email.