### PR TITLE
fix: removed Skiff (since defunct and shutting down), added FE

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -286,7 +286,7 @@ This repository is regularly backed up in [archive.org](https://web.archive.org/
 
 ## Email
 
-- [Skiff Mail](https://skiff.com/) Privacy-first end-to-end encrypted email. Supports custom domain.
+- [Forward Email](https://forwardemail.net) 100% open-source, privacy-focused, encrypted email service supporting SMTP, IMAP, POP3, email API, email webhooks, regex, unlimited aliases, unlimited domains, OpenPGP/WKD, and more.
 - [10 Minute Mail](https://10minutemail.net/) Disposable, private mailboxes
 - [Cock.li](https://cock.li/) Yeah it's mail with cocks
 - [Tutanota](https://tutanota.com/) Secure, open source email service


### PR DESCRIPTION
Skiff is defunct and shutting down in 6 months, this PR removes it.

https://skiff.com/data-migration

It also adds Forward Email, which is the only 100% open source service and has been around since 2017.