### PR TITLE
Requesting to Add MCDOC

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1108,6 +1108,8 @@ premium services
 - [Steamless](https://github.com/atom0s/Steamless) Steamless is a DRM remover of the SteamStub variants.
 - [MachineGunnur/GOG-Games](https://github.com/MachineGunnur/GOG-Games) A fork of Good Old Downloads' "GOG Games" hosted on Tor
 - [GameVault](https://gamevau.lt) a self-hosted gaming platform for DRM-free games
+- [Play retro games online](https://theretrosaga.com/) - Play NES/SNES/Sega/DOS/Arcade games in browser (no-setup)
+- [Play DOS games in browser](https://weplaydos.games/) - Play 150+ classic DOS games online (no-setup)
 - [MCDOC](https://mcdoc.openm.tech) An Index of Minecraft Tools and Unlockers
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -1108,6 +1108,7 @@ premium services
 - [Steamless](https://github.com/atom0s/Steamless) Steamless is a DRM remover of the SteamStub variants.
 - [MachineGunnur/GOG-Games](https://github.com/MachineGunnur/GOG-Games) A fork of Good Old Downloads' "GOG Games" hosted on Tor
 - [GameVault](https://gamevau.lt) a self-hosted gaming platform for DRM-free games
+- [MCDOC](https://mcdoc.openm.tech) An Index of Minecraft Tools and Unlockers
 
 
 ### Repacks


### PR DESCRIPTION
**What is MCDOC?**

> MCDOC is the ultimate list for all Minecraft related Tools and Unlockers. It contains tools for Bedrock, Education, China, Legends, Dungeons, Earth and their cross platform versions but doesnt contain Java (since there are already too much of Indexes containing them). It also wraps up the Story of Cracking MCBE, Secret Marketplace Items and Guides.

Website: [https://mcdoc.openm.tech/](https://mcdoc.openm.tech/)

***Published by [OpenM Team](https://github.com/OpenM-Project)***